### PR TITLE
Implement ExpectArray.unordered_eq

### DIFF
--- a/expect-json/src/expect/ops/expect_array/expect_array.rs
+++ b/expect-json/src/expect/ops/expect_array/expect_array.rs
@@ -60,7 +60,7 @@ impl ExpectArray {
     /// Expects all values in the array match the expected values in some order.
     /// This can be an exact value, or an `ExpectOp`.
     /// The lengths of the arrays must be equal.
-    pub fn unordered_eq<I, V>(mut self, expected_values: I) -> Self
+    pub fn eq_unordered<I, V>(mut self, expected_values: I) -> Self
     where
         I: IntoIterator<Item = V>,
         V: Into<Value>,
@@ -70,7 +70,7 @@ impl ExpectArray {
             .map(Into::into)
             .collect::<Vec<_>>();
         self.sub_ops
-            .push(ExpectArraySubOp::UnorderedEq(inner_expected_values));
+            .push(ExpectArraySubOp::EqUnordered(inner_expected_values));
         self
     }
 
@@ -492,7 +492,7 @@ mod test_unordered_match {
     #[test]
     fn it_should_pass_when_arrays_match_unordered() {
         let left = json!([1, 2, 3]);
-        let right = json!(expect::array().unordered_eq([3, 2, 1]));
+        let right = json!(expect::array().eq_unordered([3, 2, 1]));
 
         let output = expect_json_eq(&left, &right);
         assert!(output.is_ok(), "assertion error: {output:#?}");
@@ -501,7 +501,7 @@ mod test_unordered_match {
     #[test]
     fn it_should_fail_when_arrays_do_not_match_unordered() {
         let left = json!([1, 2, 3]);
-        let right = json!(expect::array().unordered_eq([4, 5, 6]));
+        let right = json!(expect::array().eq_unordered([4, 5, 6]));
 
         let output = expect_json_eq(&left, &right).unwrap_err().to_string();
         assert_eq!(
@@ -515,7 +515,7 @@ mod test_unordered_match {
     #[test]
     fn it_should_fail_when_arrays_have_different_lengths() {
         let left = json!([1, 2, 3]);
-        let right = json!(expect::array().unordered_eq([1, 2, 3, 4]));
+        let right = json!(expect::array().eq_unordered([1, 2, 3, 4]));
         let output = expect_json_eq(&left, &right).unwrap_err().to_string();
         assert_eq!(
             output,
@@ -528,7 +528,7 @@ mod test_unordered_match {
     #[test]
     fn it_should_pass_with_complex_matches() {
         let left = json!(["Alice", "Bob", "Charlie"]);
-        let right = json!(expect::array().unordered_eq([
+        let right = json!(expect::array().eq_unordered([
             expect::string().contains("C"),
             expect::string().contains("A"),
             expect::string().contains("B"),
@@ -542,7 +542,7 @@ mod test_unordered_match {
         // If we used greedy matching, "Alice" would match to the first expect::string(),
         // then "Charlie" would fail.
         let left = json!(["Alice", "Bob", "Charlie"]);
-        let right = json!(expect::array().unordered_eq([
+        let right = json!(expect::array().eq_unordered([
             expect::string(),
             expect::string().contains("B"),
             expect::string().contains("A"),
@@ -554,7 +554,7 @@ mod test_unordered_match {
     #[test]
     fn it_should_pass_with_equal_elements() {
         let left = json!(["Alice", "Alice", "Alice"]);
-        let right = json!(expect::array().unordered_eq([
+        let right = json!(expect::array().eq_unordered([
             expect::string().contains("A"),
             expect::string().contains("A"),
             expect::string().contains("A"),
@@ -566,7 +566,7 @@ mod test_unordered_match {
     #[test]
     fn it_should_pass_on_a_multiset_with_bijection() {
         let left = json!(["Alice", "Alice", "Bob"]);
-        let right = json!(expect::array().unordered_eq(["Bob", "Alice", "Alice"]));
+        let right = json!(expect::array().eq_unordered(["Bob", "Alice", "Alice"]));
         let output = expect_json_eq(&left, &right);
         assert!(output.is_ok(), "assertion error: {output:#?}");
     }
@@ -576,7 +576,7 @@ mod test_unordered_match {
         // Both "Bob" and "Boris" should match the same expect::string().contains("B"),
         // so there is no way to have a perfect matching.
         let left = json!(["Alice", "Bob", "Boris"]);
-        let right = json!(expect::array().unordered_eq([
+        let right = json!(expect::array().eq_unordered([
             expect::string().contains("A"),
             expect::string().contains("A"),
             expect::string().contains("B"),

--- a/expect-json/src/expect/ops/expect_array/expect_array_sub_op.rs
+++ b/expect-json/src/expect/ops/expect_array/expect_array_sub_op.rs
@@ -18,7 +18,7 @@ pub enum ExpectArraySubOp {
     Len(usize),
     MaxLen(usize),
     Contains(Vec<Value>),
-    UnorderedEq(Vec<Value>),
+    EqUnordered(Vec<Value>),
     AllUnique,
     AllEqual(Value),
 }
@@ -39,8 +39,8 @@ impl ExpectArraySubOp {
             Self::Contains(expected_values) => {
                 Self::on_array_contains(expected_values, parent, context, received)
             }
-            Self::UnorderedEq(expected_values) => {
-                Self::on_array_unordered_eq(expected_values, parent, context, received)
+            Self::EqUnordered(expected_values) => {
+                Self::on_array_eq_unordered(expected_values, parent, context, received)
             }
             Self::AllUnique => Self::on_array_unique(parent, context, received),
             Self::AllEqual(expected_value) => {
@@ -169,7 +169,7 @@ impl ExpectArraySubOp {
         Ok(())
     }
 
-    fn on_array_unordered_eq(
+    fn on_array_eq_unordered(
         expected_values: &[Value],
         _parent: &ExpectArray,
         context: &mut Context<'_>,

--- a/expect-json/src/expect_core/expect_op_error.rs
+++ b/expect-json/src/expect_core/expect_op_error.rs
@@ -111,6 +111,17 @@ pub enum ExpectOpError {
     },
 
     #[error(
+        "Json expect::array() error at {context}, mismatch:
+    expected array (up to order): {expected_array},
+    received array: {received_array}",
+    )]
+    ArrayUnorderedMismatch {
+        context: Context<'static>,
+        expected_array: ArrayObject,
+        received_array: ArrayObject,
+    },
+
+    #[error(
         "Json expect::integer() error at {context}, is zero:
     expected non-zero integer
     received {received}"

--- a/expect-json/src/internals/utils/bipartite_match.rs
+++ b/expect-json/src/internals/utils/bipartite_match.rs
@@ -1,0 +1,38 @@
+// Find the best matching in a bipartite graph using the Hopcroft-Karp algorithm.
+pub fn bipartite_match(
+    size: usize,
+    edges: &[(usize, usize)]
+) -> Vec<Option<usize>> {
+    let mut adj_list: Vec<Vec<usize>> = vec![Vec::new(); size];
+    for &(u, v) in edges {
+        adj_list[u].push(v);
+    }
+
+    let mut match_to: Vec<Option<usize>> = vec![None; size];
+
+    for u in 0..size {
+        let mut visited = vec![false; size];
+        bpm_dfs(u, &adj_list, &mut visited, &mut match_to);
+    }
+
+    match_to
+}
+
+fn bpm_dfs(
+    u: usize,
+    adj_list: &Vec<Vec<usize>>,
+    visited: &mut Vec<bool>,
+    match_to: &mut Vec<Option<usize>>,
+) -> bool {
+    for &v in &adj_list[u] {
+        if !visited[v] {
+            visited[v] = true;
+
+            if match_to[v].is_none() || bpm_dfs(match_to[v].unwrap(), adj_list, visited, match_to) {
+                match_to[v] = Some(u);
+                return true;
+            }
+        }
+    }
+    false
+}

--- a/expect-json/src/internals/utils/mod.rs
+++ b/expect-json/src/internals/utils/mod.rs
@@ -1,2 +1,4 @@
 mod js_identifiers;
 pub use self::js_identifiers::*;
+mod bipartite_match;
+pub use self::bipartite_match::*;


### PR DESCRIPTION
Implemented unordered_eq for array expectations:
```rust
expect_json_eq(json!(["Alice", "Bob", "Charlie"],
    expect::array().unordered_eq(json!([
        "Bob",
        expect::string(),
        expect::string().contains("A")
]))
```
succeeds as "Alice" matches to the third element, "Bob" to the first element, and "Charlie" to the second element